### PR TITLE
Add page to provide CircleCI artifact URL shortener

### DIFF
--- a/circle/index.html
+++ b/circle/index.html
@@ -1,0 +1,17 @@
+<html>
+<script type="text/javascript">
+<!--
+(function() {
+  var query = window.location.search.substring(1);
+  if (query.match(/[0-9]+/)) {
+    window.location.href = 'https://' + query + '-843222-gh.circle-artifacts.com/0/home/ubuntu/scikit-learn/doc/_build/html/stable/index.html';
+  } else {
+    var href_sans_query = window.location.href.substring(0, window.location.href.length - window.location.search.length)
+    document.write('<p>Expected numeric query string to redirect to scikit-learn documentation build on CircleCI, e.g. ' + href_sans_query
++ '?12345.</p>')
+  }
+})();
+-->
+</script>
+<noscript>This page requries JavaScript</noscript>
+</html>


### PR DESCRIPTION
This aims to simplify something like https://github.com/scikit-learn/scikit-learn/pull/7855. With this PR, we can go to http://scikit-learn.org/circle?123 to view the documentation from Circle build 123.