### PR TITLE
Update Circle CI paths

### DIFF
--- a/circle/index.html
+++ b/circle/index.html
@@ -15,7 +15,7 @@
         path += '/index.html';
       }
     }
-    window.location.href = 'https://' + ci_id + '-843222-gh.circle-artifacts.com/0/home/ubuntu/scikit-learn/doc/_build/html/stable' + path;
+    window.location.href = 'https://' + ci_id + '-843222-gh.circle-artifacts.com/0/doc' + path;
   } else {
     var href_sans_query = window.location.href.substring(0, window.location.href.length - window.location.search.length);
     document.write('<p>Expected numeric query string and optional path to redirect to scikit-learn documentation build on CircleCI, e.g. <tt>' + href_sans_query + '?12345/modules/classes.html</tt>.</p>');


### PR DESCRIPTION
We changed the paths when introducing Circle testing on Python 2.

This will break some old links, but I feel it is still useful. Sometimes the browser script doesn't behave for me, and this is easier to advise users to use...

Ping @lesteve, @albertcthomas