### PR TITLE
Script to warn when viewing version other than stable

### DIFF
--- a/versionwarning.js
+++ b/versionwarning.js
@@ -1,0 +1,31 @@
+(() => {
+    var latestStable = '0.21';
+    var goodPaths = ['stable', 'dev', latestStable];
+    var showWarning = (msg) => {
+        $('.body[role=main]').prepend(
+            '<p style="' +
+            [
+                'padding: 1em',
+                'font-size: 1.5em',
+                'border: 1px solid red',
+                'background: pink',
+                'width: 100%',
+            ].join('; ') +
+            '">' + msg + '</p>')
+    };
+    if (location.hostname == 'scikit-learn.org') {
+        var versionPath = location.pathname.split('/')[1];
+        if (!goodPaths.includes(versionPath)) {
+            showWarning('You are looking at documentation for an old release of ' +
+                        'Scikit-learn (version ' + versionPath + '). Try the ' +
+                        '<a href="https://scikit-learn.org">latest release</a> or ' +
+                        '<a href="https://scikit-learn.org/dev">development</a> ' +
+                        'versions.')
+        } else if (versionPath == 'dev') {
+            showWarning('You are looking at documentation for the unstable ' +
+                        'development version of Scikit-learn. See also the ' +
+                        '<a href="https://scikit-learn.org">latest release</a> ' +
+                        'version.')
+        }
+    }
+})()

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -1,4 +1,4 @@
-(() => {
+(function() {
     var latestStable = '0.21';
     var goodPaths = ['stable', 'dev', latestStable];
     var showWarning = (msg) => {
@@ -16,16 +16,19 @@
     if (location.hostname == 'scikit-learn.org') {
         var versionPath = location.pathname.split('/')[1];
         if (!goodPaths.includes(versionPath)) {
-            showWarning('You are looking at documentation for an old release of ' +
+            showWarning('This is documentation for an old release of ' +
                         'Scikit-learn (version ' + versionPath + '). Try the ' +
-                        '<a href="https://scikit-learn.org">latest release</a> or ' +
+                        '<a href="https://scikit-learn.org">latest stable ' +
+                        'release</a> (version ' + latestStable + ') or ' +
                         '<a href="https://scikit-learn.org/dev">development</a> ' +
-                        'versions.')
+                        '(unstable) versions.')
         } else if (versionPath == 'dev') {
-            showWarning('You are looking at documentation for the unstable ' +
-                        'development version of Scikit-learn. See also the ' +
-                        '<a href="https://scikit-learn.org">latest release</a> ' +
-                        'version.')
+            showWarning('This is documentation for the unstable ' +
+                        'development version of Scikit-learn. (To use it, ' +
+                        '<a href="https://scikit-learn.org/stable/developers/advanced_installation.html#installing-nightly-builds">install the nightly build</a>.) ' + 
+                        'The latest stable ' +
+                        'release is <a href="https://scikit-learn.org">version ' +
+                        latestStable + '</a>.')
         }
     }
 })()


### PR DESCRIPTION
This script would be available to work with the following change to all HTML files here:
```
$ find */ -name "*.html" | xargs sed -i '/<\/body>/ i \
\    <script src="https://scikit-learn.org/versionwarning.js"></script>'
```

It produces banners like the following on the dev version:

![image](https://user-images.githubusercontent.com/78827/62678278-6807a100-b9f4-11e9-9672-bb268d19d792.png)

and the following on older versions:

![image](https://user-images.githubusercontent.com/78827/62678422-d5b3cd00-b9f4-11e9-9c3b-c348a87c6c9f.png)

Inserting the script would be done in another PR, and as a change in our Circle CI doc deployment.

To do after merge:
* [ ] Add script to *.html in released directories.
* [ ] Add script during doc build/deploy for all non-pr builds (https://github.com/scikit-learn/scikit-learn/pull/14634)
* [ ] Amend maintainer docs to make sure the latest release variable is updated with minor releases (https://github.com/scikit-learn/scikit-learn/pull/14634)
* [ ] Road test and iterate on the script.