### PR TITLE
Add robots.txt to avoid indexing sphinx-pydata-theme preview

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+# Do not let search engines index the PyData theme preview site
+# during the live testing phase.
+# https://github.com/scikit-learn/scikit-learn/pull/28353
+Disallow: /_pst_preview/

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 # Do not let search engines index the PyData theme preview site
 # during the live testing phase.
 # https://github.com/scikit-learn/scikit-learn/pull/28353
+User-agent: *
 Disallow: /_pst_preview/


### PR DESCRIPTION
Simpler alternative to https://github.com/scikit-learn/scikit-learn/pull/28376 that does not seem to copy robots.txt in the right folder.

Related to https://github.com/scikit-learn/scikit-learn/issues/28084.